### PR TITLE
feat: Add extra arguments to pass to wsimport

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ task wsimport(type: uk.co.boothen.gradle.wsimport.WsImport) {
     wsdl("create/Create.wsdl") {
         bindingFile("create/bindings-create.xml")
         xjcarg("-XautoNameResolution")
+        extraArg("-J-Djavax.xml.accessExternalDTD=all")
     }
 
     wsdl ("find/Find.wsdl") {

--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
@@ -58,6 +58,11 @@ public class WsImportRunnable implements Runnable {
             xjcarg.setValue(wsdlXlcArg);
         }
 
+        Commandline.Argument extraArgs = wsImport2.createArg();
+        for (String extraArg : wsImportConfiguration.getWsdl().getExtraArgs()) {
+            extraArgs.setValue(extraArg);
+        }
+
         for (File binding : wsImportConfiguration.bindingFiles()) {
             wsImport2.setBinding(binding.getAbsolutePath());
         }

--- a/src/main/java/uk/co/boothen/gradle/wsimport/Wsdl.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/Wsdl.java
@@ -13,6 +13,7 @@ public class Wsdl implements Serializable {
     private String wsdlLocation;
     private List<String> bindingFiles = new ArrayList<>();
     private List<String> xjcargs = new ArrayList<>();
+    private List<String> extraArgs = new ArrayList<>();
 
     public Wsdl(String file) {
 
@@ -67,5 +68,18 @@ public class Wsdl implements Serializable {
     @Input
     public void xjcarg(String xjcarg) {
         this.xjcargs.add(xjcarg);
+    }
+
+    public List<String> getExtraArgs() {
+        return extraArgs;
+    }
+
+    public void setExtraArgs(List<String> extraArgs) {
+        this.extraArgs = extraArgs;
+    }
+
+    @Input
+    public void extraArg(String extraArg) {
+        this.extraArgs.add(extraArg);
     }
 }


### PR DESCRIPTION
Enables each `wsdl` config to specify any extra args.

For example

```groovy
wsdl("create/Create.wsdl") {
  bindingFile("create/bindings-create.xml")
  xjcarg("-XautoNameResolution")
  extraArg("-J-Djavax.xml.accessExternalDTD=all")
}
```