### PR TITLE
Pass down classpath to wsimport process

### DIFF
--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImport.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImport.java
@@ -9,11 +9,13 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerExecutor;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -205,19 +207,21 @@ public class WsImport extends DefaultTask {
         for (Wsdl wsdl : wsdls) {
             getWorkerExecutor().submit(WsImportRunnable.class, workerConfiguration -> {
                 workerConfiguration.setDisplayName("Importing WSDL");
-                workerConfiguration.setParams(new WsImportConfiguration(wsdlSourceRoot,
-                                                                        generatedSourceRoot,
-                                                                        generatedClassesRoot,
-                                                                        keep,
-                                                                        extension,
-                                                                        verbose,
-                                                                        quiet,
-                                                                        debug,
-                                                                        xnocompile,
-                                                                        xadditionalHeaders,
-                                                                        xnoAddressingDatabinding,
-                                                                        xdebug,
-                                                                        target,
+                workerConfiguration.setParams(new WsImportConfiguration(
+                        wsdlSourceRoot,
+                        generatedSourceRoot,
+                        generatedClassesRoot,
+                        jaxwsToolsConfiguration.getFiles().stream().map(File::toString).collect(Collectors.joining(File.pathSeparator)),
+                        keep,
+                        extension,
+                        verbose,
+                        quiet,
+                        debug,
+                        xnocompile,
+                        xadditionalHeaders,
+                        xnoAddressingDatabinding,
+                        xdebug,
+                        target,
                         encoding, wsdl));
                 workerConfiguration.classpath(jaxwsToolsConfiguration.getFiles());
             });

--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImportConfiguration.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImportConfiguration.java
@@ -10,6 +10,7 @@ public class WsImportConfiguration implements Serializable {
     private final String sourceRoot;
     private final File generatedSourceRoot;
     private final File generatedClassesRoot;
+    private final String classpath;
 
     private final boolean keep;
     private final boolean extension;
@@ -29,6 +30,7 @@ public class WsImportConfiguration implements Serializable {
     public WsImportConfiguration(String sourceRoot,
                                  File generatedSourceRoot,
                                  File generatedClassesRoot,
+                                 String classpath,
                                  boolean keep,
                                  boolean extension,
                                  boolean verbose,
@@ -43,6 +45,7 @@ public class WsImportConfiguration implements Serializable {
         this.sourceRoot = sourceRoot;
         this.generatedSourceRoot = generatedSourceRoot;
         this.generatedClassesRoot = generatedClassesRoot;
+        this.classpath = classpath;
         this.keep = keep;
         this.extension = extension;
         this.verbose = verbose;
@@ -67,6 +70,10 @@ public class WsImportConfiguration implements Serializable {
 
     public File getGeneratedClassesRoot() {
         return generatedClassesRoot;
+    }
+
+    public String getClasspath() {
+        return classpath;
     }
 
     public boolean isKeep() {

--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
@@ -55,9 +55,8 @@ public class WsImportRunnable implements Runnable {
 //        wsImport2.setImplServiceName();
 //        wsImport2.setXUseBaseResourceAndURLToLoadWSDL();
 
-        Commandline.Argument xjcarg = wsImport2.createXjcarg();
-        for (String wsdlXlcArg : wsImportConfiguration.getWsdl().getXjcargs()) {
-            xjcarg.setValue(wsdlXlcArg);
+        for (String wsdlXjcArg : wsImportConfiguration.getWsdl().getXjcargs()) {
+            wsImport2.createXjcarg().setValue(wsdlXjcArg);
         }
 
         Commandline.Argument extraArgs = wsImport2.createArg();

--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImportRunnable.java
@@ -69,6 +69,8 @@ public class WsImportRunnable implements Runnable {
             wsImport2.setBinding(binding.getAbsolutePath());
         }
 
+        System.setProperty("java.class.path", '"' + wsImportConfiguration.getClasspath() + '"');
+
         wsImport2.execute();
     }
 }


### PR DESCRIPTION
This was necessary to allow adding toString / equals / hashcode to generated output, which is also supported by the maven plugin.

It can be used in this way:

```
dependencies {
    jaxWsTools("org.jvnet.jaxb2_commons:jaxb2-basics-runtime:0.11.0")
    jaxWsTools("org.jvnet.jaxb2_commons:jaxb2-basics:0.11.0")
}
...
    wsdl("create/Create.wsdl") {
        bindingFile("create/bindings-create.xml")
        xjcarg("-Xequals")
        xjcarg("-XhashCode")
        xjcarg("-XtoString")
    }
```