### PR TITLE
add property Wsdl.catalog to config WsImport2.setCatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ wsdlLocation | String | The wsdl URI passed thru this option will be used to set
 The following properties have not been exposed from the Ant task to the plugin. If you need any of them in your configuration submit a PR or an Issue and we'll add it in.
 ```
 //        wsImport2.setXauthfile();
-//        wsImport2.setCatalog();
 //        wsImport2.setClientjar();
 //        wsImport2.setdisableAuthenticator();
 //        wsImport2.setGenerateJWS();

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'groovy-base'
     id 'java-gradle-plugin'
     id 'maven-publish'
     id "com.gradle.plugin-publish" version "0.9.10"
@@ -16,6 +17,8 @@ dependencies {
     implementation group: 'javax.jws', name: 'javax.jws-api', version: '1.1'
 
     implementation gradleApi()
+
+    testImplementation group: 'org.spockframework', name:'spock-core', version:'1.3-groovy-2.5'
 }
 
 group = "uk.co.boothen.gradle"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.daemon=false
 
-pluginVersion = 0.15
+pluginVersion = 0.16
 
 javacRelease=1.8

--- a/src/main/java/uk/co/boothen/gradle/wsimport/WsImportWorkAction.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/WsImportWorkAction.java
@@ -59,9 +59,12 @@ public abstract class WsImportWorkAction implements WorkAction<WsImportWorkParam
             wsImport2.setWsdllocation(wsdl.getWsdlLocation());
         }
 
+        if (!"".equals(wsdl.getCatalog())) {
+            wsImport2.setCatalog(new File(wsdl.getCatalog()));
+        }
+
         // TODO: Expose some of this properties
 //        wsImport2.setXauthfile();
-//        wsImport2.setCatalog();
 //        wsImport2.setClientjar();
 //        wsImport2.setdisableAuthenticator();
 //        wsImport2.setGenerateJWS();

--- a/src/main/java/uk/co/boothen/gradle/wsimport/Wsdl.java
+++ b/src/main/java/uk/co/boothen/gradle/wsimport/Wsdl.java
@@ -29,6 +29,7 @@ public class Wsdl implements Serializable {
     private List<String> bindingFiles = new ArrayList<>();
     private List<String> xjcargs = new ArrayList<>();
     private List<String> extraArgs = new ArrayList<>();
+    private String catalog = "";
 
     public Wsdl(String file) {
         this.file = file;
@@ -105,5 +106,14 @@ public class Wsdl implements Serializable {
     @Input
     public void extraArg(String extraArg) {
         this.extraArgs.add(extraArg);
+    }
+
+    public String getCatalog() {
+        return catalog;
+    }
+
+    @Input
+    public void setCatalog(String catalog) {
+        this.catalog = catalog;
     }
 }

--- a/src/test/groovy/uk.co.boothen.gradle.wsimport/WsImportPluginSpec.groovy
+++ b/src/test/groovy/uk.co.boothen.gradle.wsimport/WsImportPluginSpec.groovy
@@ -1,0 +1,20 @@
+package uk.co.boothen.gradle.wsimport
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.PluginManager
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class WsImportPluginSpec extends Specification {
+
+    def 'Plugin WsImport should be applied'() {
+        when:
+            Project project = ProjectBuilder.builder().build()
+            PluginManager pluginManager = project.getPluginManager()
+            pluginManager.apply("uk.co.boothen.gradle.wsimport")
+        then:
+            pluginManager.hasPlugin("uk.co.boothen.gradle.wsimport")
+            project.getExtensions().getByType(WsImportPluginExtension.class) instanceof WsImportPluginExtension
+    }
+
+}


### PR DESCRIPTION
add property Wsdl.catalog to config WsImport2.setCatalog [-catalog <file> specify catalog file to resolve external entity references supports TR9401, XCatalog, and OASIS XML Catalog format.]